### PR TITLE
Add Postgres 13.6 with PLV8 2.3.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ These images are based on the [official Postgres image](https://hub.docker.com/r
 - [11.5](https://github.com/IonxSolutions/docker-images/tree/master/postgres-plv8/11.5)
 - [12.2](https://github.com/IonxSolutions/docker-images/tree/master/postgres-plv8/12.2)
 - [12.8](https://github.com/IonxSolutions/docker-images/tree/master/postgres-plv8/12.8)
+- [13.6](https://github.com/IonxSolutions/docker-images/tree/master/postgres-plv8/13.6)
 
 ### Usage
 ```bash

--- a/postgres-plv8/13.6/Dockerfile
+++ b/postgres-plv8/13.6/Dockerfile
@@ -1,0 +1,33 @@
+# Docker image for PostgreSQL with the plv8 extension installed
+# Note: building plv8 times out on Docker Hub, so instead we download pre-built binaries
+# Provided by Ionx Solutions: https://www.ionxsolutions.com
+
+# Begin by downloading binaries built on Debian stretch-slim
+FROM debian:stretch-slim AS staging
+
+ENV PLV8_VERSION 2.3.15
+ENV PLV8_SHASUM="d5f057d0307422c066ce87f077a22f6be7e407151a2b882270fa2420b6123dd4 plv8-${PLV8_VERSION}.7z"
+
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends curl ca-certificates p7zip
+RUN mkdir -p /tmp/plv8
+RUN curl -o /tmp/plv8/plv8-${PLV8_VERSION}.7z -SL "https://www.ionxsolutions.com/files/plv8/${PLV8_VERSION}"
+RUN cd /tmp/plv8 \
+    && echo ${PLV8_SHASUM} | sha256sum -c \
+    && 7zr x plv8-${PLV8_VERSION}.7z
+
+# Copy the plv8 build output into an image based on postgres
+FROM postgres:13.6
+LABEL description="PostgreSQL 13.6 with the plv8 extension installed" maintainer="support@ionxsolutions.com"
+ENV PLV8_VERSION 2.3.15
+
+COPY --from=staging /tmp/plv8/plv8-${PLV8_VERSION}.so /usr/lib/postgresql/${PG_MAJOR}/lib/plv8-${PLV8_VERSION}.so
+COPY --from=staging /tmp/plv8/plv8.control /tmp/plv8/plv8--${PLV8_VERSION}.sql /usr/share/postgresql/${PG_MAJOR}/extension/
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libc++1 \
+    && rm -rf /var/lib/apt/lists/* \
+    && chmod 0755 /usr/lib/postgresql/${PG_MAJOR}/lib/plv8-${PLV8_VERSION}.so \
+    && chmod 0644 /usr/share/postgresql/${PG_MAJOR}/extension/plv8.control \
+    && chmod 0644 /usr/share/postgresql/${PG_MAJOR}/extension/plv8--${PLV8_VERSION}.sql \
+    && echo 'CREATE EXTENSION plv8;' > /docker-entrypoint-initdb.d/plv8.sql

--- a/postgres-plv8/13.6/Dockerfile.build
+++ b/postgres-plv8/13.6/Dockerfile.build
@@ -1,0 +1,55 @@
+# Docker image for PostgreSQL with the plv8 extensions installed
+# Note: building plv8 from source takes a long time, and will timeout with Docker Hub's
+# automated builds. See the main Dockerfile for an image that uses pre-built binaries
+# (built using this Dockerfile.build)
+# Provided by Ionx Solutions: https://www.ionxsolutions.com
+
+# Begin by building plv8
+FROM postgres:13.6 AS build
+
+ENV PLV8_VERSION 2.3.15
+ENV PLV8_SHASUM="8a05f9d609bb79e47b91ebc03ea63b3f7826fa421a0ee8221ee21581d68cb5ba ${PLV8_VERSION}.tar.gz"
+
+RUN buildDeps="curl build-essential ca-certificates git python gnupg libc++-dev libc++abi-dev libtinfo5 libpq-dev pkg-config glib2.0 lsb-release" \
+    && apt-get update \
+    && apt-get -y remove libpq5 \
+    && apt-get install -y --no-install-recommends ${buildDeps} \
+    && echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+    && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-server-dev-$PG_MAJOR \
+    && git config --global user.email "nobody@example.com" \
+    && git config --global user.name "nobody" \
+    && mkdir -p /tmp/build \
+    && curl -o /tmp/build/${PLV8_VERSION}.tar.gz -SL "https://github.com/plv8/plv8/archive/v${PLV8_VERSION}.tar.gz" \
+    && cd /tmp/build \
+    && echo ${PLV8_SHASUM} | sha256sum -c \
+    && tar -xzf /tmp/build/${PLV8_VERSION}.tar.gz -C /tmp/build/ \
+    && cd /tmp/build/plv8-${PLV8_VERSION} \
+    && make static \
+    && make install \
+    && strip /usr/lib/postgresql/${PG_MAJOR}/lib/plv8-${PLV8_VERSION}.so \
+    && cd / \
+    && rm -rf /tmp/build \
+    && apt-get remove -y --purge ${buildDeps} \
+    && apt-get autoremove -y --purge \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the extension build output into an image based on postgres
+FROM postgres:13.6
+LABEL description="PostgreSQL with the plv8 extension installed" maintainer="support@ionxsolutions.com"
+ENV PLV8_VERSION 2.3.15
+
+COPY --from=build /usr/lib/postgresql/${PG_MAJOR}/lib/plv8-${PLV8_VERSION}.so /usr/lib/postgresql/${PG_MAJOR}/lib/plv8-${PLV8_VERSION}.so
+COPY --from=build /usr/share/postgresql/${PG_MAJOR}/extension/plv8.control /usr/share/postgresql/${PG_MAJOR}/extension/plv8.control
+COPY --from=build /usr/share/postgresql/${PG_MAJOR}/extension/plv8--${PLV8_VERSION}.sql /usr/share/postgresql/${PG_MAJOR}/extension/plv8--${PLV8_VERSION}.sql
+
+RUN cat /usr/share/postgresql/${PG_MAJOR}/extension/plv8--${PLV8_VERSION}.sql
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libc++1 \
+    && rm -rf /var/lib/apt/lists/* \
+    && chmod 0755 /usr/lib/postgresql/${PG_MAJOR}/lib/plv8-${PLV8_VERSION}.so \
+    && chmod 0644 /usr/share/postgresql/${PG_MAJOR}/extension/plv8.control \
+    && chmod 0644 /usr/share/postgresql/${PG_MAJOR}/extension/plv8--${PLV8_VERSION}.sql \
+    && echo 'CREATE EXTENSION plv8;' > /docker-entrypoint-initdb.d/plv8.sql


### PR DESCRIPTION
Added latest 13.x version with PLV8 2.3.15.
For now I decided to hold off upgrading to PLV8 v3 for compatibility concerns, it will be required for Postgres 14.
See resulting docker image [here](https://hub.docker.com/layers/199298631/markotny/postgres-plv8/13.6/images/sha256-c3eba80791c39306cfe1adca813801bca12bba6ba3dd423b95a153a74316f872)